### PR TITLE
Add <ES6 syntax error to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,30 @@
 5. Når det kommer til Ether på testnettet er dette noe vi kan provide under workshoppen :)
 
 Nedlastning av virtuell maskin: https://drive.google.com/file/d/0B7hH5Ns5xLvhNjhIUm5TQnRrZWs/view
+
+# Troubleshooting
+
+1. `testrpc` feiler umiddelbart med følgende stack trace
+    ```javascript
+    /usr/local/lib/node_modules/ethereumjs-testrpc/build/cli.node.js:30305
+    function VM (opts = {}) {
+                  ^
+
+    SyntaxError: Unexpected token =
+        at exports.runInThisContext (vm.js:53:16)
+        at Module._compile (module.js:374:25)
+        at Object.Module._extensions..js (module.js:417:10)
+        at Module.load (module.js:344:32)
+        at Function.Module._load (module.js:301:12)
+        at Function.Module.runMain (module.js:442:10)
+        at startup (node.js:136:18)
+        at node.js:966:3
+    ```
+
+  * Grunn: [ethereumjs-vm bruker ES6 etter at `node` 6.9.1 har fått LTS](https://github.com/ethereumjs/testrpc/issues/216#issuecomment-264552034)
+  * Fix: Oppgrader `node` til nyeste stabile versjon
+      ```shell
+      $ npm cache clean -f
+      $ npm install -g n
+      $ n stable
+      ```


### PR DESCRIPTION
Add a troubleshooting section w/ fix for too low `node` version